### PR TITLE
User/abhadauria1/adding vs test v3

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -413,6 +413,8 @@ Tasks/VsTestV1/    @rasunkar  @microsoft\adoautotest
 
 Tasks/VsTestV2/    @rasunkar  @microsoft\adoautotest
 
+Tasks/VsTestV3/    @rasunkar  @microsoft\adoautotest
+
 Tasks/VsTestPlatformToolInstallerV1/   @rasunkar  @microsoft\adoautotest
 
 Tasks/WindowsMachineFileCopyV1/    @vsebesta   @rvairavelu   @pipeline-environment-team

--- a/make-options.json
+++ b/make-options.json
@@ -181,6 +181,7 @@
         "VSBuildV1",
         "VsTestV1",
         "VsTestV2",
+        "VsTestV3",
         "VsTestPlatformToolInstallerV1",
         "WindowsMachineFileCopyV1",
         "WindowsMachineFileCopyV2",


### PR DESCRIPTION
**Task name**: added vsTestV3

**Description**: added major version of vsTest task as V3

**Documentation changes required:** N (We are providing work around for the internal Microsoft customer by enabling ##VSO commands when the task is run in restricted mode.)

**Added unit tests:** N

**Attached related issue:** N

**Checklist**:
- [X] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [X] Checked that applied changes work as expected


followed this document: https://mseng.visualstudio.com/AzureDevOps/_wiki/wikis/AzureDevOps.wiki/19338/Adding-a-new-Azure-Pipelines-Task?anchor=azure-pipelines-task-sdk
